### PR TITLE
Avoid lazy initialization of Mutex

### DIFF
--- a/lib/backport/client.rb
+++ b/lib/backport/client.rb
@@ -16,6 +16,7 @@ module Backport
     def initialize input, output, adapter, remote = {}
       @in = input
       @out = output
+      @mutex = Mutex.new
       @adapter = make_adapter(adapter, remote)
       @stopped = true
       @buffer = ''
@@ -94,9 +95,7 @@ module Backport
     end
 
     # @return [Mutex]
-    def mutex
-      @mutex ||= Mutex.new
-    end
+    attr_reader :mutex
 
     # Start the thread that checks the input IO for client data.
     #

--- a/lib/backport/machine.rb
+++ b/lib/backport/machine.rb
@@ -4,6 +4,7 @@ module Backport
   class Machine
     def initialize
       @stopped = true
+      @mutex = Mutex.new
     end
 
     # Run the machine. If a block is provided, it gets executed before the
@@ -66,9 +67,7 @@ module Backport
     private
 
     # @return [Mutex]
-    def mutex
-      @mutex ||= Mutex.new
-    end
+    attr_reader :mutex
 
     # Start the thread that updates servers via the #tick method.
     #


### PR DESCRIPTION
Move initialization of the `Mutex` to the constructor.

  - this change helps platforms without a GIL/GLV
  - essentially the same change as https://github.com/castwide/solargraph/pull/299
